### PR TITLE
fail-safe for when the bug that causes it to stop happens

### DIFF
--- a/fishSol.ahk
+++ b/fishSol.ahk
@@ -264,6 +264,10 @@ if (toggle) {
         */
         MouseClick, Left
         sleep 300
+        MouseMove, 1167, 477, 3
+        Sleep 300
+        MouseClick, Left
+        Sleep 300
         cycleCount++
     }
 }


### PR DESCRIPTION
For context, the bug that causes the fishing bar and the "fish caught!" screen to be in the middle in a tiny box

I don't have a monitor with a higher res than 1080p, so I am unable to give the appropriate change for anything higher, but :/